### PR TITLE
FIX: reviewed flagged uploads shouldn't recalculate their score.

### DIFF
--- a/models/reviewable_upload.rb
+++ b/models/reviewable_upload.rb
@@ -74,9 +74,8 @@ class ReviewableUpload < Reviewable
 
   def post; end
 
-  def successful_transition(to_state, update_flag_status, recalculate_score: true)
+  def successful_transition(to_state, update_flag_status)
     create_result(:success, to_state)  do |result|
-      result.recalculate_score = recalculate_score
       result.update_flag_stats = { status: update_flag_status, user_ids: [created_by_id] }
     end
   end

--- a/models/scanned_upload.rb
+++ b/models/scanned_upload.rb
@@ -67,7 +67,8 @@ class ScannedUpload < ActiveRecord::Base
       reviewable.update!(target_created_by: upload.user)
       reviewable.add_score(
         system_user, ReviewableScore.types[:malicious_file],
-        created_at: reviewable.created_at, reason: 'malicious_file'
+        created_at: reviewable.created_at, reason: 'malicious_file',
+        force_review: true
       )
 
       SystemMessage.new(upload.user).create('malicious_file', filename: upload.original_filename)


### PR DESCRIPTION
Related to discourse/discourse#13009. These reviewables are never re-flagged, so "recalculate_score" is not necessary.

We should pass the force_review option, so they should always appear in the queue. We already do this for other automatically flagged items.