### PR TITLE
FEATURE: Temporarily disable file scanning if we can't reach ClamAV.

### DIFF
--- a/app/controllers/discourse_antivirus/antivirus_controller.rb
+++ b/app/controllers/discourse_antivirus/antivirus_controller.rb
@@ -5,10 +5,9 @@ module DiscourseAntivirus
     requires_plugin 'discourse-antivirus'
 
     def index
-      render json: {
-        versions: DiscourseAntivirus::ClamAV.instance.versions,
-        background_scan_stats: DiscourseAntivirus::BackgroundScan.stats
-      }
+      antivirus = DiscourseAntivirus::ClamAV.instance
+
+      render json: DiscourseAntivirus::BackgroundScan.new(antivirus).stats
     end
   end
 end

--- a/assets/javascripts/discourse/discourse-antivirus/connectors/admin-dashboard-top/clamav-unavailable-notice.hbs
+++ b/assets/javascripts/discourse/discourse-antivirus/connectors/admin-dashboard-top/clamav-unavailable-notice.hbs
@@ -1,0 +1,3 @@
+<div class="alert alert-error">
+  {{i18n "antivirus.clamav_unavailable"}}
+</div>

--- a/assets/javascripts/discourse/discourse-antivirus/connectors/admin-dashboard-top/clamav-unavailable-notice.js.es6
+++ b/assets/javascripts/discourse/discourse-antivirus/connectors/admin-dashboard-top/clamav-unavailable-notice.js.es6
@@ -1,0 +1,5 @@
+export default {
+  shouldRender(args, component) {
+    return component.site.clamav_unreacheable;
+  },
+};

--- a/assets/stylesheets/hide-malicious-file-flag.scss
+++ b/assets/stylesheets/hide-malicious-file-flag.scss
@@ -1,3 +1,0 @@
-.controls.malicious_file {
-  display: none;
-}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -16,6 +16,7 @@ en:
       version: Version
       database_version: Database version
       database_updated_at: Last database update
+      clamav_unavailable: We cannot establish a connection with the antivirus software. File scanning will be temporarily disabled.
 
       stats:
         total_scans: Scanned Files

--- a/jobs/scheduled/scan_batch.rb
+++ b/jobs/scheduled/scan_batch.rb
@@ -7,8 +7,11 @@ module Jobs
     def execute(_args)
       return unless SiteSetting.discourse_antivirus_enabled?
 
-      scanner = DiscourseAntivirus::BackgroundScan.new(DiscourseAntivirus::ClamAV.instance)
-      scanner.scan_batch
+      pool = DiscourseAntivirus::ClamAVServicesPool.new
+      return unless pool.accepting_connections?
+      antivirus = DiscourseAntivirus::ClamAV.instance(sockets_pool: pool)
+
+      DiscourseAntivirus::BackgroundScan.new(antivirus).scan_batch
     end
   end
 end

--- a/lib/discourse_antivirus/background_scan.rb
+++ b/lib/discourse_antivirus/background_scan.rb
@@ -6,7 +6,7 @@ module DiscourseAntivirus
       @antivirus = antivirus
     end
 
-    def self.stats
+    def stats
       scanned_upload_stats = DB.query_single(<<~SQL
         SELECT
           SUM(scans),
@@ -17,15 +17,14 @@ module DiscourseAntivirus
       )
 
       {
-        scans: scanned_upload_stats[0] || 0,
-        recently_scanned: scanned_upload_stats[1] || 0,
-        quarantined: scanned_upload_stats[2] || 0,
-        found: ReviewableUpload.count
+        versions: @antivirus.versions,
+        background_scan_stats: {
+          scans: scanned_upload_stats[0] || 0,
+          recently_scanned: scanned_upload_stats[1] || 0,
+          quarantined: scanned_upload_stats[2] || 0,
+          found: ReviewableUpload.count
+        }
       }
-    end
-
-    def current_database_version
-      @antivirus.versions.first[:database]
     end
 
     def queue_batch(batch_size: 1000)
@@ -63,6 +62,12 @@ module DiscourseAntivirus
 
         scanned_upload.update_using!(result, current_database_version)
       end
+    end
+
+    private
+
+    def current_database_version
+      @antivirus.versions.first[:database]
     end
   end
 end

--- a/lib/discourse_antivirus/clamav.rb
+++ b/lib/discourse_antivirus/clamav.rb
@@ -7,8 +7,8 @@ module DiscourseAntivirus
     STORE_KEY = 'clamav-versions'
     DOWNLOAD_FAILED = 'Download failed'
 
-    def self.instance
-      new(Discourse.store, DiscourseAntivirus::ClamAVServicesPool.new)
+    def self.instance(sockets_pool: DiscourseAntivirus::ClamAVServicesPool.new)
+      new(Discourse.store, sockets_pool)
     end
 
     def initialize(store, clamav_services_pool)

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -2,6 +2,8 @@
 
 module DiscourseAntivirus
   class ClamAVServicesPool
+    UNAVAILABLE = 'unavailable'
+
     def self.correctly_configured?
       return true if Rails.env.test?
 
@@ -13,7 +15,9 @@ module DiscourseAntivirus
     end
 
     def accepting_connections?
-      tcp_socket.nil?
+      tcp_socket.present?.tap do |available|
+        PluginStore.set(DiscourseAntivirus::ClamAV::PLUGIN_NAME, UNAVAILABLE, !available)
+      end
     end
 
     def tcp_socket

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -12,6 +12,10 @@ module DiscourseAntivirus
       end
     end
 
+    def accepting_connections?
+      tcp_socket.nil?
+    end
+
     def tcp_socket
       build_socket(service_instance.targets.first)
     end
@@ -23,7 +27,11 @@ module DiscourseAntivirus
     private
 
     def build_socket(target)
-      TCPSocket.new(target.hostname, target.port)
+      return if target.nil?
+      return if target.hostname.blank?
+      return if target.port.blank?
+
+      TCPSocket.new(target.hostname, target.port) rescue nil
     end
 
     def service_instance


### PR DESCRIPTION
If we can no longer reach ClamAV, we'll stop live and background scanning of files. Additionally, we'll show an alert in the admin dashboard.