### PR TITLE
DEV: Send a ping to ClamAV when checking if it's accepting connections.

### DIFF
--- a/jobs/scheduled/scan_batch.rb
+++ b/jobs/scheduled/scan_batch.rb
@@ -7,9 +7,8 @@ module Jobs
     def execute(_args)
       return unless SiteSetting.discourse_antivirus_enabled?
 
-      pool = DiscourseAntivirus::ClamAVServicesPool.new
-      return unless pool.accepting_connections?
-      antivirus = DiscourseAntivirus::ClamAV.instance(sockets_pool: pool)
+      antivirus = DiscourseAntivirus::ClamAV.instance
+      return unless antivirus.accepting_connections?
 
       DiscourseAntivirus::BackgroundScan.new(antivirus).scan_batch
     end

--- a/lib/discourse_antivirus/clamav.rb
+++ b/lib/discourse_antivirus/clamav.rb
@@ -6,9 +6,10 @@ module DiscourseAntivirus
     PLUGIN_NAME = 'discourse-antivirus'
     STORE_KEY = 'clamav-versions'
     DOWNLOAD_FAILED = 'Download failed'
+    UNAVAILABLE = 'unavailable'
 
-    def self.instance(sockets_pool: DiscourseAntivirus::ClamAVServicesPool.new)
-      new(Discourse.store, sockets_pool)
+    def self.instance
+      new(Discourse.store, DiscourseAntivirus::ClamAVServicesPool.new)
     end
 
     def initialize(store, clamav_services_pool)
@@ -27,7 +28,7 @@ module DiscourseAntivirus
           read_until(socket, "\0")
         end
 
-        antivirus_version = antivirus_version.gsub('1: ', '').strip.split('/')
+        antivirus_version = clean_msg(antivirus_version).split('/')
 
         {
           antivirus: antivirus_version[0],
@@ -38,6 +39,24 @@ module DiscourseAntivirus
 
       PluginStore.set(PLUGIN_NAME, STORE_KEY, antivirus_versions)
       antivirus_versions
+    end
+
+    def accepting_connections?
+      sockets = clamav_services_pool.all_tcp_sockets
+
+      if sockets.empty?
+        update_status(true)
+        return false
+      end
+
+      available = sockets.reduce(true) do |memo, socket|
+        memo && target_online?(socket)
+      end
+
+      available.tap do |status|
+        unavailable = !status
+        update_status(unavailable)
+      end
     end
 
     def scan_upload(upload)
@@ -61,6 +80,25 @@ module DiscourseAntivirus
     private
 
     attr_reader :store, :clamav_services_pool
+
+    def update_status(unavailable)
+      PluginStore.set(PLUGIN_NAME, UNAVAILABLE, unavailable)
+    end
+
+    def target_online?(socket)
+      return false if socket.nil?
+
+      ping_result = with_session(socket: socket) do |s|
+        s.send("zPING\0", 0)
+        read_until(s, "\0")
+      end
+
+      clean_msg(ping_result) == 'PONG'
+    end
+
+    def clean_msg(raw)
+      raw.gsub('1: ', '').strip
+    end
 
     def with_session(socket: clamav_services_pool.tcp_socket)
       open_session(socket)

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -14,12 +14,6 @@ module DiscourseAntivirus
       end
     end
 
-    def accepting_connections?
-      tcp_socket.present?.tap do |available|
-        PluginStore.set(DiscourseAntivirus::ClamAV::PLUGIN_NAME, UNAVAILABLE, !available)
-      end
-    end
-
     def tcp_socket
       build_socket(service_instance.targets.first)
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,7 +39,7 @@ after_initialize do
   add_to_serializer(:site, :clamav_unreacheable, false) do
     !!PluginStore.get(
       DiscourseAntivirus::ClamAV::PLUGIN_NAME,
-      DiscourseAntivirus::ClamAVServicesPool::UNAVAILABLE
+      DiscourseAntivirus::ClamAV::UNAVAILABLE
     )
   end
 
@@ -57,10 +57,10 @@ after_initialize do
     should_scan_file = !upload.for_export && (!is_image || SiteSetting.antivirus_live_scan_images)
 
     if validate && should_scan_file && upload.valid?
-      pool = DiscourseAntivirus::ClamAVServicesPool.new
+      antivirus = DiscourseAntivirus::ClamAV.instance
 
-      if pool.accepting_connections?
-        is_positive = DiscourseAntivirus::ClamAV.instance(sockets_pool: pool).scan_file(file)[:found]
+      if antivirus.accepting_connections?
+        is_positive = antivirus.scan_file(file)[:found]
 
         upload.errors.add(:base, I18n.t('scan.virus_found')) if is_positive
       end

--- a/spec/lib/discourse_antivirus/clamav_spec.rb
+++ b/spec/lib/discourse_antivirus/clamav_spec.rb
@@ -38,7 +38,7 @@ describe DiscourseAntivirus::ClamAV do
     let(:database_version) { '25853' }
     let(:last_update) { 'Wed Jun 24 10:13:27 2020' }
 
-    let(:socket) { FakeTCPSocket.new("1: #{antivirus_version}/#{database_version}/#{last_update}\0") }
+    let(:socket) { FakeTCPSocket.new(["1: #{antivirus_version}/#{database_version}/#{last_update}\0"]) }
 
     let(:antivirus) do
       build_antivirus(

--- a/spec/support/fake_tcp_socket.rb
+++ b/spec/support/fake_tcp_socket.rb
@@ -1,29 +1,37 @@
 # frozen_string_literal: true
 class FakeTCPSocket
-  def self.positive
-    new("1: stream: Win.Test.EICAR_HDB-1 FOUND\0")
+  def self.positive(include_pong: false)
+    responses = include_pong ? ["1: PONG\0"] : []
+    responses << "1: stream: Win.Test.EICAR_HDB-1 FOUND\0"
+    new(responses)
   end
 
-  def self.negative
-    new("1: stream: OK\0")
+  def self.negative(include_pong: false)
+    responses = include_pong ? ["1: PONG\0"] : []
+    responses << "1: stream: OK\0"
+    new(responses)
   end
 
-  def initialize(canned_response)
-    @canned_response = canned_response
+  def initialize(canned_responses)
+    @canned_responses = canned_responses
     @received_before_close = []
     @received = []
     @next_to_read = 0
+    @current_response = 0
   end
 
   attr_reader :received, :received_before_close
-  attr_accessor :canned_response
+  attr_accessor :canned_responses
 
   def send(text, _)
     received << text
   end
 
   def getc
-    canned_response[@next_to_read].tap { |_| @next_to_read += 1 }
+    canned_responses[@current_response][@next_to_read].tap do |c|
+      @next_to_read += 1
+      @current_response += 1 if c == "\0"
+    end
   end
 
   def close


### PR DESCRIPTION
We previously only checked if we could open a TCP socket with the server running ClamAV, but now we also send a ping and expect a pong in response. I plan to use this to add a Prometheus metric.