### PR TITLE
FEATURE: Export health metrics to Prometheus.

### DIFF
--- a/lib/discourse_antivirus/clamav_health_metric.rb
+++ b/lib/discourse_antivirus/clamav_health_metric.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DiscourseAntivirus
+  class ClamAVHealthMetric < ::DiscoursePrometheus::InternalMetric::Custom
+    attribute :name , :labels, :description, :value, :type
+
+    def initialize
+      @name = 'clamav_available'
+      @description = 'Whether or not ClamAV is accepting connections'
+      @type = "Gauge"
+    end
+
+    def collect
+      @@clamav_stats ||= {}
+      last_check = @@clamav_stats[:last_check]
+
+      if (!last_check || should_recheck?(last_check))
+        antivirus = DiscourseAntivirus::ClamAV.instance
+        available = antivirus.accepting_connections? ? 1 : 0
+
+        @@clamav_stats[:status] = available
+        @@clamav_stats[:last_check] = Time.now.to_i
+      end
+
+      @value = @@clamav_stats[:status]
+    end
+
+    private
+
+    def should_recheck?(last_check)
+      interval_seconds = 60
+
+      Time.now.to_i - last_check > interval_seconds
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -66,4 +66,9 @@ after_initialize do
       end
     end
   end
+
+  if defined?(::DiscoursePrometheus)
+    require_dependency File.expand_path('../lib/discourse_antivirus/clamav_health_metric.rb', __FILE__)
+    DiscoursePluginRegistry.register_global_collector(DiscourseAntivirus::ClamAVHealthMetric, self)
+  end
 end


### PR DESCRIPTION
Adds a health check job and export the result to Prometheus through an event. It uses the recently added `ClamAV#accepting_connections?`, which sends a ping through a TCP socket.