### PR TITLE
DEV: Use the new API for building reviewable score links to settings.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -14,7 +14,7 @@ en:
   
   reviewables:
     reasons:
-      malicious_file: The antivirus flagged this file as malicious. See more at `antivirus` settings.
+      malicious_file: The antivirus flagged this file as malicious. See more at %{link}.
 
   reviewable_score_types:
     malicious_file:

--- a/plugin.rb
+++ b/plugin.rb
@@ -71,4 +71,6 @@ after_initialize do
     require_dependency File.expand_path('../lib/discourse_antivirus/clamav_health_metric.rb', __FILE__)
     DiscoursePluginRegistry.register_global_collector(DiscourseAntivirus::ClamAVHealthMetric, self)
   end
+
+  add_reviewable_score_link(:malicious_file, 'plugin:discourse-antivirus')
 end


### PR DESCRIPTION
Discourse 2.8 added a new API for building links to site settings in the reviewable score reason. Before this API, we used backticks for this feature, but that proved problematic, as I explained [here](https://github.com/discourse/discourse/pull/14475).