### PR TITLE
DEV: Don't use a custom reviewable score type.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,8 @@ en:
   reviewables:
     reasons:
       malicious_file: The antivirus flagged this file as malicious. See more at %{link}.
+    reason_titles:
+      malicious_file: Malicious file
 
   system_messages:
     malicious_file:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -16,10 +16,6 @@ en:
     reasons:
       malicious_file: The antivirus flagged this file as malicious. See more at %{link}.
 
-  reviewable_score_types:
-    malicious_file:
-      title: Malicious file
-  
   system_messages:
     malicious_file:
       subject_template: A file uploaded by you was flagged as malicious

--- a/db/migrate/20220317175006_update_reviewable_upload_score_type.rb
+++ b/db/migrate/20220317175006_update_reviewable_upload_score_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class UpdateReviewableUploadScoreType < ActiveRecord::Migration[6.1]
+  def up
+    DB.exec <<~SQL
+      UPDATE reviewable_scores
+      SET reviewable_score_type = 9
+      WHERE reason = 'malicious_file'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/models/scanned_upload.rb
+++ b/models/scanned_upload.rb
@@ -66,7 +66,7 @@ class ScannedUpload < ActiveRecord::Base
       )
       reviewable.update!(target_created_by: upload.user)
       reviewable.add_score(
-        system_user, ReviewableScore.types[:malicious_file],
+        system_user, ReviewableScore.types[:needs_approval],
         created_at: reviewable.created_at, reason: 'malicious_file',
         force_review: true
       )
@@ -77,11 +77,5 @@ class ScannedUpload < ActiveRecord::Base
         post.rebake!(invalidate_oneboxes: true, invalidate_broken_images: true)
       end
     end
-  end
-
-  private
-
-  def handle_scan_result(result)
-    result[:found] ? move_to_quarantine!(result[:message]) : save!
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,8 +33,7 @@ after_initialize do
   require_dependency File.expand_path('../jobs/scheduled/flag_quarantined_uploads.rb', __FILE__)
 
   register_reviewable_type ReviewableUpload
-
-  replace_flags(settings: PostActionType.flag_settings, score_type_names: %i[malicious_file])
+  add_reviewable_score_link(:malicious_file, 'plugin:discourse-antivirus')
 
   add_to_serializer(:site, :clamav_unreacheable, false) do
     !!PluginStore.get(
@@ -71,6 +70,4 @@ after_initialize do
     require_dependency File.expand_path('../lib/discourse_antivirus/clamav_health_metric.rb', __FILE__)
     DiscoursePluginRegistry.register_global_collector(DiscourseAntivirus::ClamAVHealthMetric, self)
   end
-
-  add_reviewable_score_link(:malicious_file, 'plugin:discourse-antivirus')
 end


### PR DESCRIPTION
Using a custom score type is not necessary since we don't care about that type's bonus. ReviewableUploads are always created using `force_review: true`.