### PR TITLE
FIX: Improve scanning and error handling under different scenarios.

### DIFF
--- a/models/scanned_upload.rb
+++ b/models/scanned_upload.rb
@@ -9,7 +9,7 @@ class ScannedUpload < ActiveRecord::Base
 
   def update_using!(result, database_version)
     if result[:error]
-      self.next_scan_at = 1.day.from_now
+      self.next_scan_at = 6.hours.from_now
       self.last_scan_failed = true
       self.scan_result = result[:message]
     else

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -105,6 +105,7 @@ describe DiscourseAntivirus do
   end
 
   def mock_antivirus(socket)
+    IO.stubs(:select).returns(true)
     pool = OpenStruct.new(tcp_socket: socket, all_tcp_sockets: [socket])
     antivirus = DiscourseAntivirus::ClamAV.new(Discourse.store, pool)
     DiscourseAntivirus::ClamAV.expects(:instance).returns(antivirus)

--- a/spec/support/fake_tcp_socket.rb
+++ b/spec/support/fake_tcp_socket.rb
@@ -12,6 +12,10 @@ class FakeTCPSocket
     new(responses)
   end
 
+  def self.error
+    new(["1: INSTREAM size limit exceeded. ERROR\0"])
+  end
+
   def initialize(canned_responses)
     @canned_responses = canned_responses
     @received_before_close = []


### PR DESCRIPTION
This PR packs a bunch of fixes and improvements to how we scan uploads and handle different errors. We logged unhandled exceptions in the ClamAV client class, which helped us identify these issues. I'll break them down one by one:

---

`undefined method `read' for nil:NilClass while data = file.read(2048)`

Our store may return nil if it fails to download the upload from the store. Mark the scanned upload as failed with a custom error message and retry in 6hs.

`no implicit conversion of nil into String` - `Broken pipe - send(2)` - `Connection reset by peer - send(2)`

From the [ClamAV docs](https://linux.die.net/man/8/clamd):

```
Clamd requires clients to read all the replies it sent, before sending more commands to prevent send() deadlocks.

[...]

If clamd detects that a client has deadlocked, it will close the connection. Note that clamd may close an IDSESSION connection too if you don't follow the protocol's requirements. The client can use the PING command to keep the connection alive.
```

We read the ClamAV response from the socket using `getc`, which can return `nil`. To mitigate this issue, we use `IO#select` with a timeout to wait until we can read from the socket instead of doing it inmediately after streaming the file.

Since we receive `nil` and left unread messages, ClamAV thinks we deadlocked, resetting the connection when we try to scan the next upload.

Finally, we also need to handle when they send us an error response, so if the result contains the substring `ERROR`, we assume the scan failed and retry again in 6 hours. One of the errors is because the file is too large, and it turns out we are scanning data exports sent by system. We should skip those, so I tweaked the `BackgroundScan#queue_batch` query to reflect it.