### PR TITLE
FIX: Prevent deadlocks while communicating with ClamAV.

### DIFF
--- a/spec/lib/discourse_antivirus/clamav_spec.rb
+++ b/spec/lib/discourse_antivirus/clamav_spec.rb
@@ -9,7 +9,7 @@ describe DiscourseAntivirus::ClamAV do
 
   before do
     file.rewind
-    IO.stubs(:select).returns(true)
+    IO.stubs(:select)
   end
 
   describe "#scan_upload" do
@@ -97,14 +97,14 @@ describe DiscourseAntivirus::ClamAV do
   end
 
   def assert_version_was_requested(fake_socket)
-    expected = ["nIDSESSION\n", "zVERSION\0", "nEND\0"]
+    expected = ["zIDSESSION\0", "zVERSION\0", "zEND\0"]
 
     expect(fake_socket.received_before_close).to contain_exactly(*expected)
     expect(fake_socket.received).to be_empty
   end
 
   def assert_file_was_sent_through(fake_socket, file)
-    expected = ["nIDSESSION\n", "zINSTREAM\0"]
+    expected = ["zIDSESSION\0", "zINSTREAM\0"]
 
     file.rewind
     while data = file.read(2048)
@@ -115,7 +115,7 @@ describe DiscourseAntivirus::ClamAV do
     expected << [0].pack("N")
     expected << ""
 
-    expected << "nEND\0"
+    expected << "zEND\0"
 
     expect(fake_socket.received_before_close).to contain_exactly(*expected)
     expect(fake_socket.received).to be_empty


### PR DESCRIPTION
ClamAV wants us to read/write in a [non-blocking manner](https://manpages.debian.org/testing/clamav-daemon/clamd.8.en.html#IDSESSION,) to prevent deadlocks. If they think this happened, it closes the connection, which results in a broken pipe error on send.

We need to peek into the socket buffer to make sure we can write/read from it, using [IO#select](https://www.rubydoc.info/stdlib/core/IO.select) for that.

I tested the code using [this script](https://gist.github.com/romanrizzi/7f4953671e067a189d3881c3d53f8757), and was able to perform more than 120 scans without any broken pipe error.