### PR TITLE
FIX: Scan files when a single server is online

### DIFF
--- a/lib/discourse_antivirus/clamav.rb
+++ b/lib/discourse_antivirus/clamav.rb
@@ -33,9 +33,8 @@ module DiscourseAntivirus
 
     def update_versions
       antivirus_versions =
-        clamav_services_pool.instances.map do |instance|
-          antivirus_version = with_session(instance) { |s| write_in_socket(s, "zVERSION\0") }
-          antivirus_version = clean_msg(antivirus_version).split("/")
+        clamav_services_pool.online_services.map do |service|
+          antivirus_version = service.version.split("/")
 
           {
             antivirus: antivirus_version[0],
@@ -49,35 +48,33 @@ module DiscourseAntivirus
     end
 
     def accepting_connections?
-      available = online_target.present?
+      unavailable = clamav_services_pool.all_offline?
 
-      update_status(!available)
+      PluginStore.set(PLUGIN_NAME, UNAVAILABLE, unavailable)
 
-      available
+      !unavailable
     end
 
     def scan_upload(upload)
-      begin
-        file = get_uploaded_file(upload)
+      file = get_uploaded_file(upload)
 
-        return error_response(DOWNLOAD_FAILED) if file.nil?
+      return error_response(DOWNLOAD_FAILED) if file.nil?
 
-        scan_file(file)
-      rescue OpenURI::HTTPError
-        error_response(DOWNLOAD_FAILED)
-      rescue StandardError => e
-        Rails.logger.error("Could not scan upload #{upload.id}. Error: #{e.message}")
-        error_response(e.message)
-      end
+      scan_file(file)
+    rescue OpenURI::HTTPError
+      error_response(DOWNLOAD_FAILED)
+    rescue StandardError => e
+      Rails.logger.error("Could not scan upload #{upload.id}. Error: #{e.message}")
+      error_response(e.message)
     end
 
     def scan_file(file)
-      scan_response =
-        begin
-          with_session { |socket| stream_file(socket, file) }
-        rescue StandardError => e
-          e.message
-        end
+      online_service = clamav_services_pool.find_online_service
+
+      # We open one connection to check if the service is online and another
+      # to scan the file.
+      scan_response = online_service&.scan_file(file)
+      return error_response(UNAVAILABLE) unless scan_response
 
       parse_response(scan_response)
     end
@@ -90,56 +87,12 @@ module DiscourseAntivirus
       { error: true, found: false, message: error_message }
     end
 
-    def update_status(unavailable)
-      PluginStore.set(PLUGIN_NAME, UNAVAILABLE, unavailable)
-    end
-
-    def online_target
-      clamav_services_pool.instances.find do |instance|
-        ping_result = with_session(instance) { |s| write_in_socket(s, "zPING\0") }
-
-        clean_msg(ping_result) == "PONG"
-      end
-    end
-
-    def clean_msg(raw)
-      raw.gsub("1: ", "").strip
-    end
-
-    def with_session(instance = online_target)
-      socket = instance&.connect!
-
-      raise "ERROR: socket cannot be open" if !socket
-
-      write_in_socket(socket, "zIDSESSION\0")
-
-      yield(socket)
-
-      write_in_socket(socket, "zEND\0")
-
-      response = get_full_response_from(socket)
-      socket.close
-      response
-    end
-
     def parse_response(scan_response)
       {
-        message: scan_response.gsub("1: stream:", "").gsub("\0", ""),
+        message: scan_response.gsub("stream:", "").gsub("\0", ""),
         found: scan_response.include?("FOUND"),
         error: scan_response.include?("ERROR"),
       }
-    end
-
-    def stream_file(socket, file)
-      write_in_socket(socket, "zINSTREAM\0")
-
-      while data = file.read(2048)
-        write_in_socket(socket, [data.length].pack("N"))
-        write_in_socket(socket, data)
-      end
-
-      write_in_socket(socket, [0].pack("N"))
-      write_in_socket(socket, "")
     end
 
     def get_uploaded_file(upload)
@@ -151,32 +104,6 @@ module DiscourseAntivirus
       else
         File.open(store.path_for(upload))
       end
-    end
-
-    # ClamAV wants us to read/write in a non-blocking manner to prevent deadlocks.
-    # Read more about this [here](https://manpages.debian.org/testing/clamav-daemon/clamd.8.en.html#IDSESSION,)
-    #
-    # We need to peek into the socket buffer to make sure we can write/read from it,
-    # or we risk ClamAV abruptly closing the connection.
-    # For that, we use [IO#select](https://www.rubydoc.info/stdlib/core/IO.select)
-    def write_in_socket(socket, msg)
-      IO.select(nil, [socket])
-      socket.sendmsg_nonblock(msg, 0, nil)
-    end
-
-    def read_from_socket(socket)
-      IO.select([socket])
-
-      # Returns an array with the chunk as the first element
-      socket.recvmsg_nonblock(25).to_a.first.to_s
-    end
-
-    def get_full_response_from(socket)
-      buffer = ""
-
-      buffer += read_from_socket(socket) until buffer.ends_with?("\0")
-
-      buffer
     end
   end
 end

--- a/lib/discourse_antivirus/clamav.rb
+++ b/lib/discourse_antivirus/clamav.rb
@@ -72,11 +72,12 @@ module DiscourseAntivirus
       socket = sockets.shuffle.find { |s| target_online?(s) }
       sockets.each { |s| s&.close if socket != s }
 
-      scan_response = begin
-        with_session(socket) { |s| stream_file(s, file) }
-      rescue StandardError => e
-        e.message
-      end
+      scan_response =
+        begin
+          with_session(socket) { |s| stream_file(s, file) }
+        rescue StandardError => e
+          e.message
+        end
 
       parse_response(scan_response)
     end

--- a/lib/discourse_antivirus/clamav_service.rb
+++ b/lib/discourse_antivirus/clamav_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DiscourseAntivirus
+  class ClamAVService
+    def initialize(hostname, port)
+      @hostname = hostname
+      @port = port
+    end
+
+    def connect!
+      begin
+        TCPSocket.new(@hostname, @port, connect_timeout: 3)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/lib/discourse_antivirus/clamav_service.rb
+++ b/lib/discourse_antivirus/clamav_service.rb
@@ -2,17 +2,77 @@
 
 module DiscourseAntivirus
   class ClamAVService
-    def initialize(hostname, port)
+    def initialize(connection_factory, hostname, port)
+      @connection_factory = connection_factory
       @hostname = hostname
       @port = port
     end
 
-    def connect!
-      begin
-        TCPSocket.new(@hostname, @port, connect_timeout: 3)
-      rescue StandardError
-        nil
+    def version
+      with_session { |s| write_in_socket(s, "zVERSION\0") }
+    end
+
+    def online?
+      ping_result = with_session { |s| write_in_socket(s, "zPING\0") }
+
+      ping_result == "PONG"
+    end
+
+    def scan_file(file)
+      with_session do |socket|
+        write_in_socket(socket, "zINSTREAM\0")
+
+        while data = file.read(2048)
+          write_in_socket(socket, [data.length].pack("N"))
+          write_in_socket(socket, data)
+        end
+
+        write_in_socket(socket, [0].pack("N"))
+        write_in_socket(socket, "")
       end
+    end
+
+    private
+
+    attr_reader :connection_factory, :hostname, :port, :connection
+
+    def with_session
+      socket = connection_factory.call(hostname, port)
+      return if socket.nil?
+
+      write_in_socket(socket, "zIDSESSION\0")
+
+      yield(socket)
+
+      write_in_socket(socket, "zEND\0")
+
+      response = get_full_response_from(socket)
+      socket.close
+      response
+    end
+
+    # ClamAV wants us to read/write in a non-blocking manner to prevent deadlocks.
+    # Read more about this [here](https://manpages.debian.org/testing/clamav-daemon/clamd.8.en.html#IDSESSION,)
+    #
+    # We need to peek into the socket buffer to make sure we can write/read from it,
+    # or we risk ClamAV abruptly closing the connection.
+    # For that, we use [IO#select](https://www.rubydoc.info/stdlib/core/IO.select)
+    def write_in_socket(socket, msg)
+      IO.select(nil, [socket])
+      socket.sendmsg_nonblock(msg, 0, nil)
+    end
+
+    def get_full_response_from(socket)
+      buffer = +""
+
+      until buffer.ends_with?("\0")
+        IO.select([socket])
+
+        # Returns an array with the chunk as the first element
+        buffer << socket.recvmsg_nonblock(25).to_a.first.to_s
+      end
+
+      buffer.gsub("1: ", "").strip
     end
   end
 end

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -26,7 +26,7 @@ module DiscourseAntivirus
       return if target.port.blank?
 
       begin
-        TCPSocket.new(target.hostname, target.port)
+        TCPSocket.new(target.hostname, target.port, connect_timeout: 3)
       rescue StandardError
         nil
       end

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -2,49 +2,23 @@
 
 module DiscourseAntivirus
   class ClamAVServicesPool
-    UNAVAILABLE = "unavailable"
-
-    def self.correctly_configured?
-      return true if Rails.env.test?
-
-      if Rails.env.production?
-        SiteSetting.antivirus_srv_record.present?
-      else
-        GlobalSetting.respond_to?(:clamav_hostname) && GlobalSetting.respond_to?(:clamav_port)
-      end
-    end
-
-    def all_tcp_sockets
-      service_instance.targets.map { |target| build_socket(target) }
+    def instances
+      @instances ||=
+        servers
+          .filter { |server| server&.hostname.present? && server&.port.present? }
+          .map { |server| ClamAVService.new(server.hostname, server.port) }
     end
 
     private
 
-    def build_socket(target)
-      return if target.nil?
-      return if target.hostname.blank?
-      return if target.port.blank?
-
-      begin
-        TCPSocket.new(target.hostname, target.port, connect_timeout: 3)
-      rescue StandardError
-        nil
-      end
-    end
-
-    def service_instance
-      @instance ||=
+    def servers
+      @servers ||=
         if Rails.env.production?
-          DNSSD::ServiceInstance.new(Resolv::DNS::Name.create(SiteSetting.antivirus_srv_record))
+          DNSSD::ServiceInstance.new(
+            Resolv::DNS::Name.create(SiteSetting.antivirus_srv_record),
+          ).targets
         else
-          OpenStruct.new(
-            targets: [
-              OpenStruct.new(
-                hostname: GlobalSetting.clamav_hostname,
-                port: GlobalSetting.clamav_port,
-              ),
-            ],
-          )
+          [OpenStruct.new(hostname: GlobalSetting.clamav_hostname, port: GlobalSetting.clamav_port)]
         end
     end
   end

--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -14,10 +14,6 @@ module DiscourseAntivirus
       end
     end
 
-    def tcp_socket
-      build_socket(service_instance.targets.first)
-    end
-
     def all_tcp_sockets
       service_instance.targets.map { |target| build_socket(target) }
     end

--- a/lib/validators/enable_discourse_antivirus_validator.rb
+++ b/lib/validators/enable_discourse_antivirus_validator.rb
@@ -8,7 +8,7 @@ class EnableDiscourseAntivirusValidator
   def valid_value?(val)
     return true if val == "f"
 
-    DiscourseAntivirus::ClamAVServicesPool.correctly_configured?
+    DiscourseAntivirus::ClamAV.correctly_configured?
   end
 
   def error_message

--- a/plugin.rb
+++ b/plugin.rb
@@ -67,7 +67,8 @@ after_initialize do
       antivirus = DiscourseAntivirus::ClamAV.instance
 
       if antivirus.accepting_connections?
-        is_positive = antivirus.scan_file(file)[:found]
+        response = antivirus.scan_file(file)
+        is_positive = response[:found]
 
         upload.errors.add(:base, I18n.t("scan.virus_found")) if is_positive
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -58,12 +58,10 @@ after_initialize do
     if validate && should_scan_file && upload.valid?
       antivirus = DiscourseAntivirus::ClamAV.instance
 
-      if antivirus.accepting_connections?
-        response = antivirus.scan_file(file)
-        is_positive = response[:found]
+      response = antivirus.scan_file(file)
+      is_positive = response[:found]
 
-        upload.errors.add(:base, I18n.t("scan.virus_found")) if is_positive
-      end
+      upload.errors.add(:base, I18n.t("scan.virus_found")) if is_positive
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,27 +19,19 @@ load File.expand_path("lib/validators/enable_discourse_antivirus_validator.rb", 
 add_admin_route "antivirus.title", "antivirus"
 
 after_initialize do
-  require_dependency File.expand_path(
-                       "../app/controllers/discourse_antivirus/antivirus_controller.rb",
-                       __FILE__,
-                     )
-  require_dependency File.expand_path(
-                       "../lib/discourse_antivirus/clamav_services_pool.rb",
-                       __FILE__,
-                     )
-  require_dependency File.expand_path("../lib/discourse_antivirus/clamav.rb", __FILE__)
-  require_dependency File.expand_path("../lib/discourse_antivirus/background_scan.rb", __FILE__)
-  require_dependency File.expand_path("../models/scanned_upload.rb", __FILE__)
-  require_dependency File.expand_path("../models/reviewable_upload.rb", __FILE__)
-  require_dependency File.expand_path("../serializers/reviewable_upload_serializer.rb", __FILE__)
-  require_dependency File.expand_path("../jobs/scheduled/scan_batch.rb", __FILE__)
-  require_dependency File.expand_path("../jobs/scheduled/create_scanned_uploads.rb", __FILE__)
-  require_dependency File.expand_path("../jobs/scheduled/fetch_antivirus_version.rb", __FILE__)
-  require_dependency File.expand_path(
-                       "../jobs/scheduled/remove_orphaned_scanned_uploads.rb",
-                       __FILE__,
-                     )
-  require_dependency File.expand_path("../jobs/scheduled/flag_quarantined_uploads.rb", __FILE__)
+  require_relative "app/controllers/discourse_antivirus/antivirus_controller.rb"
+  require_relative "lib/discourse_antivirus/clamav_services_pool.rb"
+  require_relative "lib/discourse_antivirus/clamav_service.rb"
+  require_relative "lib/discourse_antivirus/clamav.rb"
+  require_relative "lib/discourse_antivirus/background_scan.rb"
+  require_relative "models/scanned_upload.rb"
+  require_relative "models/reviewable_upload.rb"
+  require_relative "serializers/reviewable_upload_serializer.rb"
+  require_relative "jobs/scheduled/scan_batch.rb"
+  require_relative "jobs/scheduled/create_scanned_uploads.rb"
+  require_relative "jobs/scheduled/fetch_antivirus_version.rb"
+  require_relative "jobs/scheduled/remove_orphaned_scanned_uploads.rb"
+  require_relative "jobs/scheduled/flag_quarantined_uploads.rb"
 
   register_reviewable_type ReviewableUpload
 
@@ -76,10 +68,8 @@ after_initialize do
   end
 
   if defined?(::DiscoursePrometheus)
-    require_dependency File.expand_path(
-                         "../lib/discourse_antivirus/clamav_health_metric.rb",
-                         __FILE__,
-                       )
+    require_relative "lib/discourse_antivirus/clamav_health_metric.rb"
+
     DiscoursePluginRegistry.register_global_collector(DiscourseAntivirus::ClamAVHealthMetric, self)
   end
 

--- a/spec/lib/discourse_antivirus/clamav_spec.rb
+++ b/spec/lib/discourse_antivirus/clamav_spec.rb
@@ -104,7 +104,7 @@ describe DiscourseAntivirus::ClamAV do
   end
 
   def assert_file_was_sent_through(fake_socket, file)
-    expected = ["zIDSESSION\0", "zINSTREAM\0"]
+    expected = ["zPING\0", "zIDSESSION\0", "zINSTREAM\0"]
 
     file.rewind
     while data = file.read(2048)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -107,7 +107,7 @@ describe DiscourseAntivirus do
 
   def mock_antivirus(socket)
     IO.stubs(:select).returns(true)
-    pool = FakePool.new([socket])
+    pool = FakePool.new([FakeTCPSocket.online, socket])
     antivirus = DiscourseAntivirus::ClamAV.new(Discourse.store, pool)
     DiscourseAntivirus::ClamAV.expects(:instance).returns(antivirus)
   end

--- a/spec/support/fake_pool.rb
+++ b/spec/support/fake_pool.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
-class FakePool
+class FakePool < DiscourseAntivirus::ClamAVServicesPool
   def initialize(sockets)
     @sockets = sockets
+    @connections = 0
   end
 
-  def tcp_socket
-    @sockets.first.dup
+  private
+
+  def connection_factory
+    Proc.new { @sockets[@connections].tap { @connections += 1 } }
   end
 
-  def all_tcp_sockets
-    @sockets.map(&:dup)
+  def servers
+    [OpenStruct.new(hostname: "fake.hostname", port: "8080")]
   end
 end

--- a/spec/support/fake_pool.rb
+++ b/spec/support/fake_pool.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FakePool
+  def initialize(sockets)
+    @sockets = sockets
+  end
+
+  def tcp_socket
+    @sockets.first.dup
+  end
+
+  def all_tcp_sockets
+    @sockets.map(&:dup)
+  end
+end

--- a/spec/support/fake_tcp_socket.rb
+++ b/spec/support/fake_tcp_socket.rb
@@ -1,28 +1,31 @@
 # frozen_string_literal: true
 class FakeTCPSocket
+  def self.online
+    new("1: PONG\0")
+  end
+
   def self.positive
-    new(["1: PONG\0", "1: stream: Win.Test.EICAR_HDB-1 FOUND\0"])
+    new("1: stream: Win.Test.EICAR_HDB-1 FOUND\0")
   end
 
   def self.negative
-    new(["1: PONG\0", "1: stream: OK\0"])
+    new("1: stream: OK\0")
   end
 
   def self.error
-    new(["1: PONG\0", "1: INSTREAM size limit exceeded. ERROR\0"])
+    new("1: INSTREAM size limit exceeded. ERROR\0")
   end
 
-  def initialize(canned_responses)
-    @canned_responses = canned_responses
+  def initialize(canned_response)
+    @canned_response = canned_response
     @closed = false
     @received_before_close = []
     @received = []
     @next_to_read = 0
-    @current_response = 0
   end
 
   attr_reader :received, :received_before_close
-  attr_accessor :canned_responses
+  attr_accessor :canned_response
 
   def sendmsg_nonblock(text, _, _)
     raise if @closed
@@ -35,22 +38,15 @@ class FakeTCPSocket
 
     interval_end = @next_to_read + maxlen
 
-    response_chunk = canned_responses[@current_response][@next_to_read..interval_end]
+    response_chunk = canned_response[@next_to_read..interval_end]
 
-    if response_chunk.ends_with?("\0")
-      @current_response += 1
-      @next_to_read = 0
-    else
-      @next_to_read += interval_end + 1
-    end
+    @next_to_read += interval_end + 1 unless response_chunk.ends_with?("\0")
 
     [response_chunk]
   end
 
   def close
     @closed = true
-    @next_to_read = 0
     @received_before_close = @received
-    @received = []
   end
 end

--- a/spec/support/fake_tcp_socket.rb
+++ b/spec/support/fake_tcp_socket.rb
@@ -1,23 +1,20 @@
 # frozen_string_literal: true
 class FakeTCPSocket
-  def self.positive(include_pong: false)
-    responses = include_pong ? ["1: PONG\0"] : []
-    responses << "1: stream: Win.Test.EICAR_HDB-1 FOUND\0"
-    new(responses)
+  def self.positive
+    new(["1: PONG\0", "1: stream: Win.Test.EICAR_HDB-1 FOUND\0"])
   end
 
-  def self.negative(include_pong: false)
-    responses = include_pong ? ["1: PONG\0"] : []
-    responses << "1: stream: OK\0"
-    new(responses)
+  def self.negative
+    new(["1: PONG\0", "1: stream: OK\0"])
   end
 
   def self.error
-    new(["1: INSTREAM size limit exceeded. ERROR\0"])
+    new(["1: PONG\0", "1: INSTREAM size limit exceeded. ERROR\0"])
   end
 
   def initialize(canned_responses)
     @canned_responses = canned_responses
+    @closed = false
     @received_before_close = []
     @received = []
     @next_to_read = 0
@@ -28,10 +25,14 @@ class FakeTCPSocket
   attr_accessor :canned_responses
 
   def sendmsg_nonblock(text, _, _)
+    raise if @closed
+
     received << text
   end
 
   def recvmsg_nonblock(maxlen)
+    raise if @closed
+
     interval_end = @next_to_read + maxlen
 
     response_chunk = canned_responses[@current_response][@next_to_read..interval_end]
@@ -47,6 +48,7 @@ class FakeTCPSocket
   end
 
   def close
+    @closed = true
     @next_to_read = 0
     @received_before_close = @received
     @received = []


### PR DESCRIPTION
This commits makes sure that even when a single server is online, the plugin is available. This commit also makes sure that a random and online server is chosen when using with_session without any specified socket. It used to use the first one.