### PR TITLE
FIX: Update cook-text to angle bracket syntax

### DIFF
--- a/assets/javascripts/discourse/templates/components/reviewable-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-upload.hbs
@@ -16,7 +16,7 @@
 
       <div class="post-contents">
         <div class="post-body disable-links-to-flagged-upload">
-          {{cook-text reviewable.payload.post_raw}}
+          <CookText @rawText={{reviewable.payload.post_raw}} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Since the core change (https://github.com/discourse/discourse/commit/61571bee43eae88755b5e258e96d03c146f9d2cb) of the CookText component to a Glimmer component, positional arguments are no longer supported causing the cooked text to break.

This PR updates the component usage to angle bracket syntax with named arguments to fix the issue. Since this syntax will work on older versions as well, no discourse-compatibility file update is necessary.