### PR TITLE
FIX: Use hostname and port passed to the Proc.

### DIFF
--- a/lib/discourse_antivirus/clamav_services_pool.rb
+++ b/lib/discourse_antivirus/clamav_services_pool.rb
@@ -20,7 +20,7 @@ module DiscourseAntivirus
       @factory ||=
         Proc.new do |hostname, port|
           begin
-            TCPSocket.new(@hostname, @port, connect_timeout: 3)
+            TCPSocket.new(hostname, port, connect_timeout: 3)
           rescue StandardError
             nil
           end


### PR DESCRIPTION
There are no instance variables