### PR TITLE
DEV: Use new FileStore#download! method

### DIFF
--- a/lib/discourse_antivirus/clam_av.rb
+++ b/lib/discourse_antivirus/clam_av.rb
@@ -61,7 +61,7 @@ module DiscourseAntivirus
       return error_response(DOWNLOAD_FAILED) if file.nil?
 
       scan_file(file)
-    rescue OpenURI::HTTPError
+    rescue OpenURI::HTTPError, FileStore::DownloadError
       error_response(DOWNLOAD_FAILED)
     rescue StandardError => e
       Rails.logger.error("Could not scan upload #{upload.id}. Error: #{e.message}")
@@ -100,7 +100,7 @@ module DiscourseAntivirus
         # Upload#filesize could be approximate.
         # add two extra Mbs to make sure that we'll be able to download the upload.
         max_filesize = upload.filesize + 2.megabytes
-        store.download(upload, max_file_size_kb: max_filesize)
+        store.download!(upload, max_file_size_kb: max_filesize)
       else
         File.open(store.path_for(upload))
       end

--- a/spec/lib/discourse_antivirus/background_scan_spec.rb
+++ b/spec/lib/discourse_antivirus/background_scan_spec.rb
@@ -51,7 +51,7 @@ describe DiscourseAntivirus::BackgroundScan do
       store.stubs(:external?).returns(true)
       filesize = upload.filesize + 2.megabytes
       store
-        .expects(:download)
+        .expects(:download!)
         .with(upload, max_file_size_kb: filesize)
         .raises(OpenURI::HTTPError.new("forbidden", nil))
 
@@ -73,7 +73,7 @@ describe DiscourseAntivirus::BackgroundScan do
       store = Discourse.store
       store.stubs(:external?).returns(true)
       filesize = upload.filesize + 2.megabytes
-      store.expects(:download).with(upload, max_file_size_kb: filesize).returns(nil)
+      store.expects(:download!).with(upload, max_file_size_kb: filesize).returns(nil)
 
       antivirus = DiscourseAntivirus::ClamAv.new(store, build_fake_pool(socket))
       scanner = described_class.new(antivirus)


### PR DESCRIPTION
### What is this change?

The `FileStore#download` method used to raise an error. It has now been split into `FileStore#download` (returns `nil`) and `FileStore#download!` (raises error.)

This PR updates this plugin to use the new method. It also makes sure to rescue and handle download errors coming from `FileStore`.