### PR TITLE
SECURITY: Quarantined PM uploads expose raw private-message text to non-participant moderators [backport 2026.3]

### DIFF
--- a/app/models/scanned_upload.rb
+++ b/app/models/scanned_upload.rb
@@ -44,7 +44,9 @@ class ScannedUpload < ActiveRecord::Base
     system_user = Discourse.system_user
     upload_link =
       "#{Upload.base62_sha1(upload.sha1)}#{upload.extension.present? ? ".#{upload.extension}" : ""}"
-    original_post_raw_example = upload.posts.last&.raw
+    original_post = upload.posts.last
+    original_post_raw_example = original_post&.raw
+    reviewable_topic = original_post&.topic
 
     self.class.transaction do
       uploaded_to =
@@ -59,8 +61,8 @@ class ScannedUpload < ActiveRecord::Base
         ReviewableUpload.needs_review!(
           created_by: system_user,
           target: upload,
-          reviewable_by_moderator: true,
-          topic: upload.posts.last&.topic,
+          reviewable_by_moderator: !reviewable_topic&.private_message?,
+          topic: reviewable_topic,
           payload: {
             scan_message: scan_message,
             original_filename: upload.original_filename,

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe ReviewablesController do
+  fab!(:admin)
+  fab!(:moderator)
+  fab!(:uploader, :user)
+  fab!(:participant, :user)
+
+  before { SiteSetting.discourse_antivirus_enabled = true }
+
+  describe "#show" do
+    it "hides PM raw from non-participant moderators", :aggregate_failures do
+      upload = Fabricate(:upload, user: uploader)
+      upload_link =
+        "#{Upload.base62_sha1(upload.sha1)}#{upload.extension.present? ? ".#{upload.extension}" : ""}"
+      private_message_raw = "Private message secret [file](upload://#{upload_link})"
+      private_message_topic =
+        Fabricate(:private_message_topic, user: uploader, recipient: participant)
+      post =
+        Fabricate(:post, topic: private_message_topic, user: uploader, raw: private_message_raw)
+      upload.update!(posts: [post])
+
+      scanned_upload = ScannedUpload.create!(upload: upload, quarantined: true)
+      scanned_upload.flag_upload("Eicar-Test-Signature FOUND")
+      reviewable = ReviewableUpload.find_by!(target: upload)
+
+      sign_in(moderator)
+      get "/review/#{reviewable.id}.json"
+
+      expect(response.status).to eq(404)
+      expect(response.body).not_to include(private_message_raw)
+
+      sign_in(admin)
+      get "/review/#{reviewable.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["reviewable"]["payload"]["post_raw"]).to eq(private_message_raw)
+    end
+  end
+end


### PR DESCRIPTION
Backport of https://github.com/discourse/discourse-antivirus/pull/105 to `d-compat/2026.3`.