### PR TITLE
SECURITY: Quarantined whisper uploads expose raw whisper text in the review queue

### DIFF
--- a/app/models/scanned_upload.rb
+++ b/app/models/scanned_upload.rb
@@ -46,7 +46,8 @@ class ScannedUpload < ActiveRecord::Base
       "#{Upload.base62_sha1(upload.sha1)}#{upload.extension.present? ? ".#{upload.extension}" : ""}"
     original_post = upload.posts.last
     original_post_raw_example = original_post&.raw
-    reviewable_topic = original_post&.topic
+    original_post_is_whisper = original_post&.whisper?
+    reviewable_topic = original_post_is_whisper ? nil : original_post&.topic
 
     self.class.transaction do
       uploaded_to =
@@ -61,7 +62,7 @@ class ScannedUpload < ActiveRecord::Base
         ReviewableUpload.needs_review!(
           created_by: system_user,
           target: upload,
-          reviewable_by_moderator: !reviewable_topic&.private_message?,
+          reviewable_by_moderator: !original_post_is_whisper && !reviewable_topic&.private_message?,
           topic: reviewable_topic,
           payload: {
             scan_message: scan_message,

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -36,5 +36,47 @@ RSpec.describe ReviewablesController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["reviewable"]["payload"]["post_raw"]).to eq(private_message_raw)
     end
+
+    it "hides whisper raw from non-whispering reviewers", :aggregate_failures do
+      whisperers_group = Fabricate(:group)
+      SiteSetting.whispers_allowed_groups = whisperers_group.id.to_s
+      SiteSetting.enable_category_group_moderation = true
+
+      category = Fabricate(:category)
+      category_moderator = Fabricate(:user)
+      category_moderation_group = Fabricate(:group)
+      category_moderation_group.add(category_moderator)
+      CategoryModerationGroup.create!(
+        category_id: category.id,
+        group_id: category_moderation_group.id,
+      )
+
+      upload = Fabricate(:upload, user: uploader)
+      upload_link =
+        "#{Upload.base62_sha1(upload.sha1)}#{upload.extension.present? ? ".#{upload.extension}" : ""}"
+      whisper_raw = "Private staff note [file](upload://#{upload_link})"
+      topic = Fabricate(:topic, category: category)
+      post =
+        Fabricate(
+          :post,
+          topic: topic,
+          user: uploader,
+          raw: whisper_raw,
+          post_type: Post.types[:whisper],
+        )
+      upload.update!(posts: [post])
+
+      scanned_upload = ScannedUpload.create!(upload: upload, quarantined: true)
+      scanned_upload.flag_upload("Eicar-Test-Signature FOUND")
+      reviewable = ReviewableUpload.find_by!(target: upload)
+
+      [[moderator, 404], [category_moderator, 403]].each do |reviewer, expected_status|
+        sign_in(reviewer)
+        get "/review/#{reviewable.id}.json"
+
+        expect(response.status).to eq(expected_status)
+        expect(response.body).not_to include(whisper_raw)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Prevent the exposure of sensitive whisper text to moderators and category moderators by restricting quarantined upload reviewables for whisper posts to site admins only. The fix ensures that antivirus reviewables for uploads originating from whispers are created without topic context and are explicitly excluded from moderator visibility.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1408

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>